### PR TITLE
Invalid character on return

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ export default class QueueListener extends BaseCommand {
     BullMQ.worker<TestProps, TestProps>(QueueNamesEnum.TestJob, async (job) => {
       console.log(job.data)
       // handle your job
-      åreturn job
+      return job
   })
   }
 }


### PR DESCRIPTION
Simple fix on README. There was an invalid character `å` on `return job`